### PR TITLE
Fixed Spanish ortography and wording.

### DIFF
--- a/html/eu.js
+++ b/html/eu.js
@@ -266,11 +266,11 @@ const messages = {
     },
     Español: {
         message: {
-            data_level_5: 'Vivido Aqui',
-            data_level_4: 'Quedado Aqui',
-            data_level_3: 'Visitado Aqui',
-            data_level_2: 'Detuvido Aqui',
-            data_level_1: 'Pase por Aqui',
+            data_level_5: 'Vivido aquí',
+            data_level_4: 'Quedado aquí',
+            data_level_3: 'Visitado aquí',
+            data_level_2: 'Parado aquí',
+            data_level_1: 'Pasé por aquí',
             data_level_0_alt: 'Quiero ir',
             data_level_0: 'Nunca he estado',
             pt: 'pt | pts',

--- a/html/us.js
+++ b/html/us.js
@@ -290,11 +290,11 @@ const messages = {
     },
     Español: {
         message: {
-            data_level_5: 'Vivido Aqui',
-            data_level_4: 'Quedado Aqui',
-            data_level_3: 'Visitado Aqui',
-            data_level_2: 'Detuvido Aqui',
-            data_level_1: 'Pase por Aqui',
+            data_level_5: 'Vivido aquí',
+            data_level_4: 'Quedado aquí',
+            data_level_3: 'Visitado aquí',
+            data_level_2: 'Parado aquí',
+            data_level_1: 'Pasé por aquí',
             data_level_0_alt: 'Quiero ir',
             data_level_0: 'Nunca he estado',
             pt: 'pt | pts',


### PR DESCRIPTION
The use of "detenerse" vs "pararse" can be disputed (without further context, "detenido" may be read as "arrested" while "parado" may be understood as "standing"). But, in any case, it would never be "detuvido" as in the previous commit but "detenido".