### PR TITLE
Update eu.html

### DIFF
--- a/html/eu.html
+++ b/html/eu.html
@@ -348,9 +348,9 @@ polyline{fill:none;pointer-events:none;}
 	<rect x="867.7" y="909.5" class="st9" width="154" height="49"/>
 	<text transform="matrix(1 0 0 1 929.0422 940.9233)" class="st12 st11">BiH</text>
 	<rect x="897.6" y="962.9" class="st9" width="154" height="49"/>
-	<text transform="matrix(1 0 0 1 955.8191 994.2939)" class="st12 st11">MtN</text>
+	<text transform="matrix(1 0 0 1 955.8191 994.2939)" class="st12 st11">MNE</text>
 	<rect x="975.5" y="991.2" class="st9" width="154" height="49"/>
-	<text transform="matrix(1 0 0 1 1036.5756 1021.1392)" class="st12 st22">Mac.</text>
+	<text transform="matrix(1 0 0 1 1036.5756 1021.1392)" class="st12 st22">NMK</text>
 	<rect x="714.5" y="1045.6" class="st9" width="154" height="49"/>
 	<text transform="matrix(1 0 0 1 755.8944 1076.2886)" class="st12 st19">Vatican</text>
 	<rect x="819.2" y="949.1" class="st9" width="58.6" height="49"/>


### PR DESCRIPTION
more widely known abbreviations (which are used on vehicle license plates) for Montenegro (MNE) and North Macedonia (NMK)